### PR TITLE
Support for indexing the entire twitter status JSON

### DIFF
--- a/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
+++ b/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.river.AbstractRiverComponent;
@@ -40,6 +41,7 @@ import org.elasticsearch.river.RiverSettings;
 import org.elasticsearch.threadpool.ThreadPool;
 import twitter4j.*;
 import twitter4j.conf.ConfigurationBuilder;
+import twitter4j.json.DataObjectFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -78,6 +80,8 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
     private FilterQuery filterQuery;
 
     private String streamType;
+    
+    private boolean fullStatus = false;
 
 
     private volatile TwitterStream stream;
@@ -140,6 +144,9 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
                 if (proxy.containsKey("password")) {
                     proxyPassword = XContentMapValues.nodeStringValue(proxy.get("password"), null);
                 }
+            }
+            if (twitterSettings.containsKey("full")) {
+                fullStatus = Boolean.parseBoolean(twitterSettings.get("full").toString());
             }
             streamType = XContentMapValues.nodeStringValue(twitterSettings.get("type"), "sample");
             Map<String, Object> filterSettings = (Map<String, Object>) twitterSettings.get("filter");
@@ -256,6 +263,8 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
         } else {
             cb.setUser(user).setPassword(password);
         }
+        if(fullStatus)
+            cb.setJSONStoreEnabled(true);
         if (proxyHost != null) cb.setHttpProxyHost(proxyHost);
         if (proxyPort != null) cb.setHttpProxyPort(Integer.parseInt(proxyPort));
         if (proxyUser != null) cb.setHttpProxyUser(proxyUser);
@@ -378,122 +387,135 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
                 logger.trace("status {} : {}", status.getUser().getName(), status.getText());
             }
             try {
-                XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                builder.field("text", status.getText());
-                builder.field("created_at", status.getCreatedAt());
-                builder.field("source", status.getSource());
-                builder.field("truncated", status.isTruncated());
-
-                if (status.getUserMentionEntities() != null) {
-                    builder.startArray("mention");
-                    for (UserMentionEntity user : status.getUserMentionEntities()) {
-                        builder.startObject();
-                        builder.field("id", user.getId());
-                        builder.field("name", user.getName());
-                        builder.field("screen_name", user.getScreenName());
-                        builder.field("start", user.getStart());
-                        builder.field("end", user.getEnd());
-                        builder.endObject();
-                    }
-                    builder.endArray();
-                }
-
-                if (status.getRetweetCount() != -1) {
-                    builder.field("retweet_count", status.getRetweetCount());
-                }
-
-                if (status.getInReplyToStatusId() != -1) {
-                    builder.startObject("in_reply");
-                    builder.field("status", status.getInReplyToStatusId());
-                    if (status.getInReplyToUserId() != -1) {
-                        builder.field("user_id", status.getInReplyToUserId());
-                        builder.field("user_screen_name", status.getInReplyToScreenName());
-                    }
-                    builder.endObject();
-                }
-
-                if (status.getHashtagEntities() != null) {
-                    builder.startArray("hashtag");
-                    for (HashtagEntity hashtag : status.getHashtagEntities()) {
-                        builder.startObject();
-                        builder.field("text", hashtag.getText());
-                        builder.field("start", hashtag.getStart());
-                        builder.field("end", hashtag.getEnd());
-                        builder.endObject();
-                    }
-                    builder.endArray();
-                }
-                if (status.getContributors() != null) {
-                    builder.array("contributor", status.getContributors());
-                }
-                if (status.getGeoLocation() != null) {
-                    builder.startObject("location");
-                    builder.field("lat", status.getGeoLocation().getLatitude());
-                    builder.field("lon", status.getGeoLocation().getLongitude());
-                    builder.endObject();
-                }
-                if (status.getPlace() != null) {
-                    builder.startObject("place");
-                    builder.field("id", status.getPlace().getId());
-                    builder.field("name", status.getPlace().getName());
-                    builder.field("type", status.getPlace().getPlaceType());
-                    builder.field("full_name", status.getPlace().getFullName());
-                    builder.field("street_address", status.getPlace().getStreetAddress());
-                    builder.field("country", status.getPlace().getCountry());
-                    builder.field("country_code", status.getPlace().getCountryCode());
-                    builder.field("url", status.getPlace().getURL());
-                    builder.endObject();
-                }
-                if (status.getURLEntities() != null) {
-                    builder.startArray("link");
-                    for (URLEntity url : status.getURLEntities()) {
-                        if (url != null) {
-                            builder.startObject();
-                            if (url.getURL() != null) {
-                                builder.field("url", url.getURL().toExternalForm());
-                            }
-                            if (url.getDisplayURL() != null) {
-                                builder.field("display_url", url.getDisplayURL());
-                            }
-                            if (url.getExpandedURL() != null) {
-                                builder.field("expand_url", url.getExpandedURL());
-                            }
-                            builder.field("start", url.getStart());
-                            builder.field("end", url.getEnd());
-                            builder.endObject();
-                        }
-                    }
-                    builder.endArray();
-                }
-                if (status.getAnnotations() != null) {
-                    builder.startObject("annotation");
-                    List<Annotation> annotations = status.getAnnotations().getAnnotations();
-                    for (Annotation ann : annotations) {
-                        builder.startObject(ann.getType());
-                        Map<String, String> attributes = ann.getAttributes();
-                        for (Map.Entry<String, String> entry : attributes.entrySet()) {
-                            builder.field(entry.getKey(), entry.getValue());
-                        }
-                        builder.endObject();
-                    }
-                    builder.endObject();
-                }
-
-                builder.startObject("user");
-                builder.field("id", status.getUser().getId());
-                builder.field("name", status.getUser().getName());
-                builder.field("screen_name", status.getUser().getScreenName());
-                builder.field("location", status.getUser().getLocation());
-                builder.field("description", status.getUser().getDescription());
-								builder.field("followers_count", status.getUser().getFollowersCount());
-                builder.endObject();
-
-                builder.endObject();
+                XContentBuilder builder = (fullStatus) ? buildFullDoc(status) : buildLightDoc(status);
                 currentRequest.add(Requests.indexRequest(indexName).type(typeName).id(Long.toString(status.getId())).create(true).source(builder));
                 processBulkIfNeeded();
             } catch (Exception e) {
                 logger.warn("failed to construct index request", e);
             }
+        }
+        
+        private XContentBuilder buildFullDoc(Status status) throws Exception {
+            return XContentFactory.jsonBuilder()
+                                  .copyCurrentStructure(JsonXContent
+                                                        .jsonXContent
+                                                        .createParser(DataObjectFactory.getRawJSON(status)));
+        }
+        
+        private XContentBuilder buildLightDoc(Status status) throws Exception
+        {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.field("text", status.getText());
+            builder.field("created_at", status.getCreatedAt());
+            builder.field("source", status.getSource());
+            builder.field("truncated", status.isTruncated());
+  
+            if (status.getUserMentionEntities() != null) {
+                builder.startArray("mention");
+                for (UserMentionEntity user : status.getUserMentionEntities()) {
+                    builder.startObject();
+                    builder.field("id", user.getId());
+                    builder.field("name", user.getName());
+                    builder.field("screen_name", user.getScreenName());
+                    builder.field("start", user.getStart());
+                    builder.field("end", user.getEnd());
+                    builder.endObject();
+                }
+                builder.endArray();
+            }
+  
+            if (status.getRetweetCount() != -1) {
+                builder.field("retweet_count", status.getRetweetCount());
+            }
+  
+            if (status.getInReplyToStatusId() != -1) {
+                builder.startObject("in_reply");
+                builder.field("status", status.getInReplyToStatusId());
+                if (status.getInReplyToUserId() != -1) {
+                    builder.field("user_id", status.getInReplyToUserId());
+                    builder.field("user_screen_name", status.getInReplyToScreenName());
+                }
+                builder.endObject();
+            }
+  
+            if (status.getHashtagEntities() != null) {
+                builder.startArray("hashtag");
+                for (HashtagEntity hashtag : status.getHashtagEntities()) {
+                    builder.startObject();
+                    builder.field("text", hashtag.getText());
+                    builder.field("start", hashtag.getStart());
+                    builder.field("end", hashtag.getEnd());
+                    builder.endObject();
+                }
+                builder.endArray();
+            }
+            if (status.getContributors() != null) {
+                builder.array("contributor", status.getContributors());
+            }
+            if (status.getGeoLocation() != null) {
+                builder.startObject("location");
+                builder.field("lat", status.getGeoLocation().getLatitude());
+                builder.field("lon", status.getGeoLocation().getLongitude());
+                builder.endObject();
+            }
+            if (status.getPlace() != null) {
+                builder.startObject("place");
+                builder.field("id", status.getPlace().getId());
+                builder.field("name", status.getPlace().getName());
+                builder.field("type", status.getPlace().getPlaceType());
+                builder.field("full_name", status.getPlace().getFullName());
+                builder.field("street_address", status.getPlace().getStreetAddress());
+                builder.field("country", status.getPlace().getCountry());
+                builder.field("country_code", status.getPlace().getCountryCode());
+                builder.field("url", status.getPlace().getURL());
+                builder.endObject();
+            }
+            if (status.getURLEntities() != null) {
+                builder.startArray("link");
+                for (URLEntity url : status.getURLEntities()) {
+                    if (url != null) {
+                        builder.startObject();
+                        if (url.getURL() != null) {
+                            builder.field("url", url.getURL().toExternalForm());
+                        }
+                        if (url.getDisplayURL() != null) {
+                            builder.field("display_url", url.getDisplayURL());
+                        }
+                        if (url.getExpandedURL() != null) {
+                            builder.field("expand_url", url.getExpandedURL());
+                        }
+                        builder.field("start", url.getStart());
+                        builder.field("end", url.getEnd());
+                        builder.endObject();
+                    }
+                }
+                builder.endArray();
+            }
+            if (status.getAnnotations() != null) {
+                builder.startObject("annotation");
+                List<Annotation> annotations = status.getAnnotations().getAnnotations();
+                for (Annotation ann : annotations) {
+                    builder.startObject(ann.getType());
+                    Map<String, String> attributes = ann.getAttributes();
+                    for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                        builder.field(entry.getKey(), entry.getValue());
+                    }
+                    builder.endObject();
+                }
+                builder.endObject();
+            }
+  
+            builder.startObject("user");
+            builder.field("id", status.getUser().getId());
+            builder.field("name", status.getUser().getName());
+            builder.field("screen_name", status.getUser().getScreenName());
+            builder.field("location", status.getUser().getLocation());
+            builder.field("description", status.getUser().getDescription());
+            builder.endObject();
+  
+            builder.endObject();
+            
+            return builder;
         }
 
         @Override

--- a/src/test/java/org/elasticsearch/river/twitter/TwitterRiverTest.java
+++ b/src/test/java/org/elasticsearch/river/twitter/TwitterRiverTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to ElasticSearch and Shay Banon under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.river.twitter;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.query.FilterBuilders.missingFilter;
+import static org.elasticsearch.index.query.FilterBuilders.notFilter;
+import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
+import junit.framework.Assert;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.BaseQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+
+public class TwitterRiverTest {
+  
+  protected final static ESLogger logger = Loggers.getLogger(TwitterRiverTest.class);
+  private static String           _username;
+  private static String           _password;
+  
+  public static void main(String[] args) throws Exception {
+    if (null == args || args.length != 2) {
+      System.err.println("Please provide a username and password for Twitter.");
+      System.exit(1);
+    }
+    _username = args[0];
+    _password = args[1];
+    Node node = NodeBuilder.nodeBuilder()
+                           .settings(ImmutableSettings.settingsBuilder().put("gateway.type", "none"))
+                           .node();
+    
+    XContentBuilder riverDefinition = jsonBuilder().startObject()
+                                                   .field("type", "twitter")
+                                                   .field("twitter")
+                                                     .startObject()
+                                                     .field("user", _username)
+                                                     .field("password", _password)
+                                                     .field("full", true)
+                                                     .endObject()
+                                                   .endObject();
+    logger.info("River Definition: {}", riverDefinition.prettyPrint().string());
+    
+    node.client()
+        .prepareIndex("_river", "twitter_river_test", "_meta")
+        .setSource(riverDefinition)
+        .execute()
+        .actionGet();
+    
+    Thread.sleep(10000);
+    
+    QueryBuilder qb = constantScoreQuery(notFilter(missingFilter("user.followers_count")));
+    logger.info("Query JSON: {}", ((BaseQueryBuilder) qb).toString());
+    SearchResponse response = node.client()
+                                  .prepareSearch("twitter_river_test")
+                                  .setQuery(qb)
+                                  .setFrom(0)
+                                  .setSize(10)
+                                  .execute()
+                                  .actionGet();
+    
+    logger.info("Found {} hits so far", response.hits().getTotalHits());
+    Assert.assertTrue("Was expecting documents with the user.followers_count field present",
+                      response.hits().getTotalHits() > 0);
+    
+    node.close();
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, out
+
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.conversionPattern=[%d{ISO8601}][%-5p][%-25c] %m%n


### PR DESCRIPTION
Heya ;-)

The devs over here @Traackr  participated in a Rackspace elasticsearch hackday back in March (http://elasticsearchhackday.eventbrite.com/). Our prototype was basic: use ES and the twitter river to look for tweets in a certain geographic area and by keyword and show the results in real-time on a map, augmented with a simplified version of the @Traackr scores (see project here git@github.com:Traackr/staalkr.git) . 

One thing we realized while we were doing this is that the current incarnation of the twitter river is pulling a limited subset of the available data from the Twitter Stream API. For instance, we needed the number of followers to do our computations. So we added a one liner back during the hackday to make it work but I always wanted to come back to it and see if it can be done in a more complete fashion.

What we propose is the addition of a "full" flag in the twitter river configuration that will allow the onStatus method to pull the full response JSON into ES. This is a more expensive operation but it would at least make it available for those that opt to use it.

Check it out and let me know what you think!

-GS
