### PR TITLE
Decremented on going bulks counter if a bulk fails or if an exception is thrown

### DIFF
--- a/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
+++ b/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
@@ -536,10 +536,12 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
 
                             @Override
                             public void onFailure(Throwable e) {
+                                onGoingBulks.decrementAndGet();
                                 logger.warn("failed to execute bulk");
                             }
                         });
                     } catch (Exception e) {
+                        onGoingBulks.decrementAndGet();
                         logger.warn("failed to process bulk", e);
                     }
                 }


### PR DESCRIPTION
Decremented on going bulks counter if a bulk fails or if an exception is thrown: if you have problems (failures or excetions) and/or a low drop_threshold configured you can end up losing documents even though no bulks are being executed.
