### PR TITLE
Added not_analyzed to retweet user_screen_name

### DIFF
--- a/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
+++ b/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
@@ -356,6 +356,7 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
                         .startObject("user").startObject("properties").startObject("screen_name").field("type", "string").field("index", "not_analyzed").endObject().endObject().endObject()
                         .startObject("mention").startObject("properties").startObject("screen_name").field("type", "string").field("index", "not_analyzed").endObject().endObject().endObject()
                         .startObject("in_reply").startObject("properties").startObject("user_screen_name").field("type", "string").field("index", "not_analyzed").endObject().endObject().endObject()
+                        .startObject("retweet").startObject("properties").startObject("user_screen_name").field("type", "string").field("index", "not_analyzed").endObject().endObject().endObject()
                         .endObject().endObject().endObject().string();
                 client.admin().indices().prepareCreate(indexName).addMapping(typeName, mapping).execute().actionGet();
             }


### PR DESCRIPTION
When the index mapping is originally created, a not_analyzed attribute value for the index property of the retweet object is added to make it similar to all other screen_name properties in the documents.
