### PR TITLE
Added follower count for the user.

### DIFF
--- a/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
+++ b/src/main/java/org/elasticsearch/river/twitter/TwitterRiver.java
@@ -748,6 +748,7 @@ public class TwitterRiver extends AbstractRiverComponent implements River {
                             builder.field("id", status.getUser().getId());
                             builder.field("name", status.getUser().getName());
                             builder.field("screen_name", status.getUser().getScreenName());
+                            builder.field("follower_count", status.getUser().getFollowersCount());
                             builder.field("location", status.getUser().getLocation());
                             builder.field("description", status.getUser().getDescription());
                             builder.field("profile_image_url", status.getUser().getProfileImageURL());


### PR DESCRIPTION
Added follower count for the user, can be useful for the impact analysis of a tweet with negative/positive sentimental polarity.